### PR TITLE
fix: no more overlapped theme icons

### DIFF
--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -32,13 +32,23 @@ import { Icon } from "astro-icon";
 		class="group relative h-9 w-9 rounded-md bg-zinc-200 p-2 ring-zinc-400 transition-all hover:ring-2 dark:bg-zinc-700"
 		aria-label="Toggle Dark Mode"
 	>
-		<Icon class="icon" aria-hidden="true" focusable="false" name="ph:sun-bold" />
-		<Icon class="icon" aria-hidden="true" focusable="false" name="ri:moon-clear-line" />
+		<Icon
+			class="icon group-aria-pressed:scale-100 group-aria-pressed:opacity-100"
+			aria-hidden="true"
+			focusable="false"
+			name="ph:sun-bold"
+		/>
+		<Icon
+			class="icon group-aria-[pressed=false]:scale-100 group-aria-[pressed=false]:opacity-100"
+			aria-hidden="true"
+			focusable="false"
+			name="ri:moon-clear-line"
+		/>
 	</button>
 </theme-toggle>
 
 <style>
 	.icon {
-		@apply absolute left-1/2 top-1/2 h-7 w-7 -translate-x-1/2 -translate-y-1/2 scale-0 opacity-0 transition-all group-aria-pressed:scale-100 group-aria-pressed:opacity-100;
+		@apply absolute left-1/2 top-1/2 h-7 w-7 -translate-x-1/2 -translate-y-1/2 scale-0 opacity-0 transition-all;
 	}
 </style>


### PR DESCRIPTION
# Description

- theme icons was overlapped

## Fix any issue(s)?

Closes #143 

## Thank you!

Thank you for opening the pull request!
