### PR TITLE
fix: get rid of the space after blogger text

### DIFF
--- a/src/components/Highlight.astro
+++ b/src/components/Highlight.astro
@@ -6,6 +6,4 @@ interface Props {
 const { text }: Props = Astro.props;
 ---
 
-<span class="font-bold text-accent">
-	{text}
-</span>
+<span class="font-bold text-accent">{text}</span>


### PR DESCRIPTION
# Description

<!-- add what are the changes -->
- get rid of strange space after blogger text

## Fix any issue(s)?

N/A

## Thank you!

Thank you for opening the pull request!
